### PR TITLE
Add blank Libero model

### DIFF
--- a/model/README.md
+++ b/model/README.md
@@ -1,0 +1,20 @@
+# Libero Model
+
+## Archimate 
+
+> Archi® is a free, open source, cross-platform tool and editor to create ArchiMate models.
+
+### Installation
+
+[Website](https://www.archimatetool.com/)
+[Github](https://github.com/archimatetool/archi)
+
+### Configuration
+
+In order to use this repository you will need the "Collaboration" menu option.
+This can be added by installing the plugin:
+
+[Website](https://www.archimatetool.com/plugins/)
+[Github](https://github.com/archimatetool/archi-modelrepository-plugin)
+
+

--- a/model/application/folder.xml
+++ b/model/application/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Application"
-    id="ff060d36-7b87-400a-bec4-bcf002cf3dbb"
+    id="3db24b4b-1b57-4721-a52f-83bca2f44c47"
     type="application"/>

--- a/model/application/folder.xml
+++ b/model/application/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Application"
+    id="ff060d36-7b87-400a-bec4-bcf002cf3dbb"
+    type="application"/>

--- a/model/business/folder.xml
+++ b/model/business/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Business"
+    id="b72298c2-3bb2-4609-bbc0-47990e0099e0"
+    type="business"/>

--- a/model/business/folder.xml
+++ b/model/business/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Business"
-    id="b72298c2-3bb2-4609-bbc0-47990e0099e0"
+    id="b8f2d6e9-4a9a-40a7-a45d-91c6480d2f23"
     type="business"/>

--- a/model/diagrams/ArchimateDiagramModel_0722a983-accd-4137-b099-4e9dcd5e6468.xml
+++ b/model/diagrams/ArchimateDiagramModel_0722a983-accd-4137-b099-4e9dcd5e6468.xml
@@ -1,0 +1,18 @@
+<archimate:ArchimateDiagramModel
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Default View"
+    id="0722a983-accd-4137-b099-4e9dcd5e6468">
+  <children
+      xsi:type="archimate:DiagramModelArchimateObject"
+      id="705bfc00-3c01-4604-80df-427254ad1eab">
+    <bounds
+        x="281"
+        y="103"
+        width="120"
+        height="55"/>
+    <archimateElement
+        xsi:type="archimate:Node"
+        href="Node_71609b71-0cb2-4894-bb92-a9776e457657.xml#71609b71-0cb2-4894-bb92-a9776e457657"/>
+  </children>
+</archimate:ArchimateDiagramModel>

--- a/model/diagrams/ArchimateDiagramModel_a477c0a7-65ec-4567-a711-7d9966c139ea.xml
+++ b/model/diagrams/ArchimateDiagramModel_a477c0a7-65ec-4567-a711-7d9966c139ea.xml
@@ -1,0 +1,4 @@
+<archimate:ArchimateDiagramModel
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Default View"
+    id="a477c0a7-65ec-4567-a711-7d9966c139ea"/>

--- a/model/diagrams/ArchimateDiagramModel_a477c0a7-65ec-4567-a711-7d9966c139ea.xml
+++ b/model/diagrams/ArchimateDiagramModel_a477c0a7-65ec-4567-a711-7d9966c139ea.xml
@@ -1,4 +1,0 @@
-<archimate:ArchimateDiagramModel
-    xmlns:archimate="http://www.archimatetool.com/archimate"
-    name="Default View"
-    id="a477c0a7-65ec-4567-a711-7d9966c139ea"/>

--- a/model/diagrams/folder.xml
+++ b/model/diagrams/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Views"
+    id="07a9c97a-2306-44c0-88ac-759dddb99e34"
+    type="diagrams"/>

--- a/model/diagrams/folder.xml
+++ b/model/diagrams/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Views"
-    id="07a9c97a-2306-44c0-88ac-759dddb99e34"
+    id="b7c4313c-87a0-4047-a25f-761f234304ea"
     type="diagrams"/>

--- a/model/folder.xml
+++ b/model/folder.xml
@@ -1,0 +1,5 @@
+<archimate:ArchimateModel
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Libero"
+    id="2530b2ec-3d9c-46ef-89eb-fb0defbdaa0c"
+    version="4.0.0"/>

--- a/model/folder.xml
+++ b/model/folder.xml
@@ -1,5 +1,5 @@
 <archimate:ArchimateModel
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Libero"
-    id="2530b2ec-3d9c-46ef-89eb-fb0defbdaa0c"
+    id="a14af0f3-4e36-42b9-8544-f3cb65b0317d"
     version="4.0.0"/>

--- a/model/implementation_migration/folder.xml
+++ b/model/implementation_migration/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Implementation &amp; Migration"
-    id="4d6f7f14-274c-4dee-b702-2c1d60f252ec"
+    id="5e12aa9b-6de0-443a-83f8-407978325d8a"
     type="implementation_migration"/>

--- a/model/implementation_migration/folder.xml
+++ b/model/implementation_migration/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Implementation &amp; Migration"
+    id="4d6f7f14-274c-4dee-b702-2c1d60f252ec"
+    type="implementation_migration"/>

--- a/model/motivation/folder.xml
+++ b/model/motivation/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Motivation"
-    id="9ae33ca7-8e18-4c0c-8f1c-cd0a2b9908e8"
+    id="683349d5-0ab0-47ab-8c5d-acaed1ac386d"
     type="motivation"/>

--- a/model/motivation/folder.xml
+++ b/model/motivation/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Motivation"
+    id="9ae33ca7-8e18-4c0c-8f1c-cd0a2b9908e8"
+    type="motivation"/>

--- a/model/other/folder.xml
+++ b/model/other/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Other"
+    id="225dadc7-358c-420d-a599-3b623c889b89"
+    type="other"/>

--- a/model/other/folder.xml
+++ b/model/other/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Other"
-    id="225dadc7-358c-420d-a599-3b623c889b89"
+    id="f4a615db-e20a-4722-9b18-cd625309bf57"
     type="other"/>

--- a/model/relations/folder.xml
+++ b/model/relations/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Relations"
+    id="e4e2199a-0109-4733-a0cc-2ee8e342b39a"
+    type="relations"/>

--- a/model/relations/folder.xml
+++ b/model/relations/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Relations"
-    id="e4e2199a-0109-4733-a0cc-2ee8e342b39a"
+    id="86daf94e-0cf8-4471-a5b4-5d1b33d8b4e1"
     type="relations"/>

--- a/model/strategy/folder.xml
+++ b/model/strategy/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Strategy"
+    id="0e3d0532-736e-4d22-8761-8c47839b1abe"
+    type="strategy"/>

--- a/model/strategy/folder.xml
+++ b/model/strategy/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Strategy"
-    id="0e3d0532-736e-4d22-8761-8c47839b1abe"
+    id="333b4bb8-0443-4b68-99f4-3604bb42c53b"
     type="strategy"/>

--- a/model/technology/Node_71609b71-0cb2-4894-bb92-a9776e457657.xml
+++ b/model/technology/Node_71609b71-0cb2-4894-bb92-a9776e457657.xml
@@ -1,0 +1,4 @@
+<archimate:Node
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Node"
+    id="71609b71-0cb2-4894-bb92-a9776e457657"/>

--- a/model/technology/folder.xml
+++ b/model/technology/folder.xml
@@ -1,0 +1,5 @@
+<archimate:Folder
+    xmlns:archimate="http://www.archimatetool.com/archimate"
+    name="Technology &amp; Physical"
+    id="95d1be6b-3601-420e-9618-72c8737be1f2"
+    type="technology"/>

--- a/model/technology/folder.xml
+++ b/model/technology/folder.xml
@@ -1,5 +1,5 @@
 <archimate:Folder
     xmlns:archimate="http://www.archimatetool.com/archimate"
     name="Technology &amp; Physical"
-    id="95d1be6b-3601-420e-9618-72c8737be1f2"
+    id="b300d6e0-b9fc-4b72-857e-5671d0e9e5cb"
     type="technology"/>


### PR DESCRIPTION
The plugin to Archi appears to use the top level /model and /images directories.