### PR TITLE
Add Libero infrastructure scope ADR

### DIFF
--- a/doc/adr/0008-libero-infrastructure.md
+++ b/doc/adr/0008-libero-infrastructure.md
@@ -25,7 +25,7 @@ Libero infrastructure should serve two purposes:
 
 ## Consequences
 
-Vanilla configuration of Libero products should always be running on Libero infrastructure.
+Demo environments for Libero products are run on Libero infrastructure.
 
 Operational aspects that can be added to an environment without changing its architecture (e.g. backups, log aggregation) are considered out of scope for Libero infrastructure.
 

--- a/doc/adr/0008-libero-infrastructure.md
+++ b/doc/adr/0008-libero-infrastructure.md
@@ -1,0 +1,34 @@
+# 8. Limit scope of Libero infrastructure
+
+Date: 2020-01-10
+
+## Status
+
+Proposed
+
+## Context
+
+Libero infrastructure (servers, Kubernetes, buckets) supports Libero development by providing demo environments.
+
+Service providers need documentation to learn to run Libero products.
+
+Service providers cater for the disparate, very specific needs of publishers.
+
+Service providers may consolidate their infrastructure with the rest of the platforms.
+
+## Decision
+
+Libero infrastructure should serve two purposes:
+
+- provide *demo* environments to showcase Libero products in certain configurations
+- provide realistic *reference* environments that do not serve real users but can be forked and adapted by service providers to kick start their Libero offering
+
+## Consequences
+
+Vanilla configuration of Libero products should always be running on Libero infrastructure.
+
+Operational aspects that can be added to an environment without changing its architecture (e.g. backups, log aggregation) are considered out of scope for Libero infrastructure.
+
+Libero Infrastructure As Code is not directly runnable by a third party.
+
+Libero Helm charts are not directly installable by a third party.


### PR DESCRIPTION
As part of the work of [deploying the first Libero product to Libero infrastructure](https://github.com/libero/publisher-chart) rather than inside eLife, it's helpful to define the reusability of the approach and of the actual code that implements it.

The [`continuous delivery` label](https://github.com/libero/publisher/issues?q=is%3Aissue+is%3Aopen+label%3A%22continuous+delivery%22) collects a series of concerns whose scope will vary significantly if we classify them as out of scope according to this decision, or we need to consider in the reference implementation.